### PR TITLE
refactor: Remove simple usages of abort function (Wave 1)

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -2,8 +2,8 @@
     Severity     = @('Error', 'Warning')
 
     ExcludeRules = @(
-        # Currently Scoop widely uses Write-Host to output colored text.
         'PSUseShouldProcessForStateChangingFunctions',
+        # Currently Scoop widely uses Write-Host to output colored text.
         'PSAvoidUsingWriteHost',
         # Temporarily allow uses of Invoke-Expression,
         # this command is used by some core functions and hard to be removed.

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -3,16 +3,17 @@ param($cmd)
 
 Set-StrictMode -Off
 
-'core', 'buckets', 'commands', 'Git' | ForEach-Object {
+'core', 'buckets', 'Helpers', 'commands', 'Git' | ForEach-Object {
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
+$exitCode = 0
 
 if (('--version' -eq $cmd) -or (!$cmd -and ('-v' -in $args))) {
     Write-UserMessage -Message 'Current Scoop (soon to be Shovel) version:' -Output
     Invoke-GitCmd -Command 'VersionLog' -Repository (versiondir 'scoop' 'current')
-    Write-UserMessage -Message ''
+    Write-UserMessage -Message '' -Output
 
     Get-LocalBucket | ForEach-Object {
         $b = Find-BucketDirectory $_ -Root
@@ -20,15 +21,16 @@ if (('--version' -eq $cmd) -or (!$cmd -and ('-v' -in $args))) {
         if (Join-Path $b '.git' | Test-Path -PathType Container) {
             Write-UserMessage -Message "'$_' bucket:" -Output
             Invoke-GitCmd -Command 'VersionLog' -Repository $b
-            Write-UserMessage -Message ''
+            Write-UserMessage -Message '' -Output
         }
     }
 } elseif ((@($null, '--help', '/?') -contains $cmd) -or ($args[0] -contains '-h')) {
-    exec 'help' $args
+    Invoke-ScoopCommand 'help' $args
 } elseif ((commands) -contains $cmd) {
-    exec $cmd $args
+    Invoke-ScoopCommand $cmd $args
 } else {
-    # TODO: Stop-ScoopExecution
-    Write-UserMessage -Message "scoop: '$cmd' isn't a scoop command. See 'scoop help'."
-    exit 1
+    Write-UserMessage -Message "scoop: '$cmd' isn't a scoop command. See 'scoop help'." -Output
+    $exitCode = 1
 }
+
+exit $exitCode

--- a/bin/scoop.ps1
+++ b/bin/scoop.ps1
@@ -26,11 +26,13 @@ if (('--version' -eq $cmd) -or (!$cmd -and ('-v' -in $args))) {
     }
 } elseif ((@($null, '--help', '/?') -contains $cmd) -or ($args[0] -contains '-h')) {
     Invoke-ScoopCommand 'help' $args
+    $exitCode = $LASTEXITCODE
 } elseif ((commands) -contains $cmd) {
     Invoke-ScoopCommand $cmd $args
+    $exitCode = $LASTEXITCODE
 } else {
     Write-UserMessage -Message "scoop: '$cmd' isn't a scoop command. See 'scoop help'." -Output
-    $exitCode = 1
+    $exitCode = 2
 }
 
 exit $exitCode

--- a/lib/Helpers.ps1
+++ b/lib/Helpers.ps1
@@ -79,6 +79,41 @@ function Write-UserMessage {
     }
 }
 
+function Stop-ScoopExecution {
+    <#
+    .SYNOPSIS
+        Print error message and exit scoop execution with given Exit code.
+    .DESCRIPTION
+        This function should be used only as the last thing, where there is not possible to recover from error state or
+        if you can freely exit entire execution without causing problems to user.
+        If it is called there is no failsafe / error state handling.
+        For Example. When there is installation of multiple applications happening, and first fail. This function
+        is called, and rest of applications are not installed, which is not user friendly.
+    .PARAMETER Message
+        Specifies the tessage, which will be printed to user.
+    .PARAMETER ExitCode
+        Specifies the exit code.
+    #>
+    param(
+        [Parameter(Position = 0, Mandatory, ValueFromPipeline, ValueFromPipelineByPropertyName)]
+        [String[]] $Message,
+        [Parameter(Position = 1, ValueFromPipelineByPropertyName)]
+        [Int] $ExitCode = 3,
+        [String[]] $Usage
+    )
+
+    begin { if ($Usage) { $ExitCode = 1 } }
+
+    process {
+        Write-UserMessage -Message $Message -Err
+        if ($Usage) {
+            Write-UserMessage -Message $Usage -Output
+        }
+    }
+
+    end { exit $ExitCode }
+}
+
 function Out-UTF8File {
     <#
     .SYNOPSIS
@@ -175,4 +210,59 @@ function Get-MagicByte {
 
         return $cont.ToUpper()
     }
+}
+
+function _resetAlias($name, $value) {
+    $existing = Get-Alias $name -ErrorAction Ignore
+
+    if ($existing -and ($existing | Where-Object -Property Options -Match 'readonly')) {
+        if ($existing.Definition -ne $value) {
+            Write-UserMessage "Alias $name is read-only; can't reset it." -Warning
+        }
+
+        # Already set
+        return
+    }
+
+    if ($value -is [ScriptBlock]) {
+        if (!(Test-Path "Function:script:$name")) {
+            New-Item -Path Function: -Name "script:$name" -Value $value | Out-Null
+        }
+
+        return
+    }
+
+    Set-Alias $name $value -Scope Script -Option AllScope
+}
+
+function Reset-Alias {
+    # For aliases where there's a local function, re-alias so the function takes precedence
+    $aliases = Get-Alias | Where-Object -Property Options -NotMatch 'readonly|allscope' | Select-Object -ExpandProperty Name
+    Get-ChildItem Function: | ForEach-Object {
+        $fn = $_.Name
+        if ($fn -in $aliases) {
+            Set-Alias $fn Local:$fn -Scope Script
+        }
+    }
+
+    # User aliases
+    $defautlAliases = @{
+        'cp'     = 'Copy-Item'
+        'echo'   = 'Write-Output'
+        'gc'     = 'Get-Content'
+        'gci'    = 'Get-ChildItem'
+        'gcm'    = 'Get-Command'
+        'gm'     = 'Get-Member'
+        'iex'    = 'Invoke-Expression'
+        'ls'     = 'Get-ChildItem'
+        'mkdir'  = { New-Item -Type Directory @args }
+        'mv'     = 'Move-Item'
+        'rm'     = 'Remove-Item'
+        'sc'     = 'Set-Content'
+        'select' = 'Select-Object'
+        'sls'    = 'Select-String'
+    }
+
+    # Set default aliases
+    $defautlAliases.Keys | ForEach-Object { _resetAlias $_ $defautlAliases[$_] }
 }

--- a/lib/Helpers.ps1
+++ b/lib/Helpers.ps1
@@ -99,13 +99,14 @@ function Stop-ScoopExecution {
         [String[]] $Message,
         [Parameter(Position = 1, ValueFromPipelineByPropertyName)]
         [Int] $ExitCode = 3,
-        [String[]] $Usage
+        [String[]] $Usage,
+        [Switch] $SkipSeverity
     )
 
     begin { if ($Usage) { $ExitCode = 1 } }
 
     process {
-        Write-UserMessage -Message $Message -Err
+        Write-UserMessage -Message $Message -Err:(!$SkipSeverity)
         if ($Usage) {
             Write-UserMessage -Message $Usage -Output
         }

--- a/lib/core.ps1
+++ b/lib/core.ps1
@@ -766,55 +766,9 @@ function pluralize($count, $singular, $plural) {
     if ($count -eq 1) { $singular } else { $plural }
 }
 
-function reset_alias($name, $value) {
-    if ($existing = Get-Alias $name -ErrorAction Ignore | Where-Object { $_.Options -match 'readonly' }) {
-        if ($existing.Definition -ne $value) {
-            Write-UserMessage "Alias $name is read-only; can't reset it." -Warning
-        }
-
-        return # already set
-    }
-    if ($value -is [ScriptBlock]) {
-        if (!(Test-Path "function:script:$name")) {
-            New-Item -Path Function: -Name "script:$name" -Value $value | Out-Null
-        }
-
-        return
-    }
-
-    Set-Alias $name $value -Scope Script -Option AllScope
-}
-
 function reset_aliases() {
-    # for aliases where there's a local function, re-alias so the function takes precedence
-    $aliases = Get-Alias | Where-Object { $_.Options -notmatch 'readonly|allscope' } | ForEach-Object { $_.name }
-    Get-ChildItem Function: | ForEach-Object {
-        $fn = $_.Name
-        if ($aliases -contains $fn) {
-            Set-Alias $fn Local:$fn -Scope Script
-        }
-    }
-
-# for dealing with user aliases
-$default_aliases = @{
-    'cp'     = 'copy-item'
-    'echo'   = 'write-output'
-    'gc'     = 'get-content'
-    'gci'    = 'get-childitem'
-    'gcm'    = 'get-command'
-    'gm'     = 'get-member'
-    'iex'    = 'invoke-expression'
-    'ls'     = 'get-childitem'
-    'mkdir'  = { New-Item -Type Directory @args }
-    'mv'     = 'move-item'
-    'rm'     = 'remove-item'
-    'sc'     = 'set-content'
-    'select' = 'select-object'
-    'sls'    = 'select-string'
-}
-
-# set default aliases
-$default_aliases.Keys | ForEach-Object { reset_alias $_ $default_aliases[$_] }
+    Show-DeprecatedWarning $MyInvocation 'Reset-Alias'
+    Reset-Alias
 }
 
 # convert list of apps to list of ($app, $global) tuples

--- a/lib/help.ps1
+++ b/lib/help.ps1
@@ -1,3 +1,7 @@
+'commands' | ForEach-Object {
+    . (Join-Path $PSScriptRoot "$_.ps1")
+}
+
 function usage($text) {
     $text | Select-String '(?m)^# Usage: ([^\n]*)$' | ForEach-Object { 'Usage: ' + $_.matches[0].Groups[1].Value }
 }
@@ -9,6 +13,31 @@ function summary($text) {
 function scoop_help($text) {
     $help_lines = $text | Select-String '(?ms)^# Help:(.(?!^[^#]))*' | ForEach-Object { $_.matches[0].Value; }
     $help_lines -replace '(?ms)^#\s?(Help: )?'
+}
+
+function print_help($cmd) {
+    $file = Get-Content (command_path $cmd) -Raw
+
+    $usage = usage $file
+    $summary = summary $file
+    $help = scoop_help $file
+
+    if ($usage) { Write-UserMessage -Message $usage -Output }
+    if ($summary) { Write-UserMessage -Message '', $summary -Output }
+    if ($help) { Write-UserMessage -Message '', $help -Output }
+}
+
+function print_summaries {
+    $commands = @{ }
+
+    command_files | ForEach-Object {
+        $command = command_name $_
+        $summary = summary (Get-Content (command_path $command) -Raw)
+        if (!($summary)) { $summary = '' }
+        $commands.Add("$command ", $summary) # add padding
+    }
+
+    $commands.GetEnumerator() | Sort-Object -Property Name | Format-Table -AutoSize -HideTableHeaders -Wrap
 }
 
 function my_usage {

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -131,8 +131,8 @@ function generate_user_manifest($app, $bucket, $version) {
     )
 
     if (!($manifest.autoupdate)) {
-        Write-UserMessage -Message "'$app' does not have autoupdate capability`r`ncouldn't find manifest for '$app@$version'" -Warn
-        return
+        Write-UserMessage -Message "'$app' does not have autoupdate capability`r`ncouldn't find manifest for '$app@$version'" -Warning
+        return $null
     }
 
     $path = usermanifestsdir | ensure

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -130,9 +130,9 @@ function generate_user_manifest($app, $bucket, $version) {
         "Attempting to generate manifest for '$app' ($version)"
     )
 
-    # TODO: Stop-ScoopExecution
     if (!($manifest.autoupdate)) {
-        abort "'$app' does not have autoupdate capability`r`ncouldn't find manifest for '$app@$version'"
+        Write-UserMessage -Message "'$app' does not have autoupdate capability`r`ncouldn't find manifest for '$app@$version'" -Warn
+        return
     }
 
     $path = usermanifestsdir | ensure
@@ -141,7 +141,7 @@ function generate_user_manifest($app, $bucket, $version) {
 
         return (usermanifest $app | Resolve-Path).Path
     } catch {
-        Write-UserMessage -Message "Could not install $app@$version" -Color DarkRed
+        throw "Could not install $app@$version"
     }
 
     return $null

--- a/libexec/scoop-alias.ps1
+++ b/libexec/scoop-alias.ps1
@@ -47,7 +47,7 @@ switch ($Option) {
         }
     }
     'list' { Get-ScoopAlias -Verbose:$Verbose }
-    default { my_usage; $exitCode = 1 }
+    default { Stop-ScoopExecution -Message 'No parameters provided' -Usage (my_usage) }
 }
 
 exit $exitCode

--- a/libexec/scoop-bucket.ps1
+++ b/libexec/scoop-bucket.ps1
@@ -24,7 +24,7 @@ param($Cmd, $Name, $Repo)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 # TODO: Remove
 $usage_add = 'usage: scoop bucket add <name> [<repo>]'

--- a/libexec/scoop-cache.ps1
+++ b/libexec/scoop-cache.ps1
@@ -15,7 +15,7 @@ param($cmd, $app)
 
 . (Join-Path $PSScriptRoot "..\lib\help.ps1")
 
-reset_aliases
+Reset-Alias
 
 function cacheinfo($file) {
     $app, $version, $url = $file.name -split '#'

--- a/libexec/scoop-cleanup.ps1
+++ b/libexec/scoop-cleanup.ps1
@@ -13,7 +13,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'gk' 'global', 'cache'
 if ($err) { Write-UserMessage -Message "scoop cleanup: $err" -Err; exit 2 }

--- a/libexec/scoop-config.ps1
+++ b/libexec/scoop-config.ps1
@@ -90,7 +90,7 @@ param($name, $value)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 if (!$name) { my_usage; exit 1 }
 

--- a/libexec/scoop-depends.ps1
+++ b/libexec/scoop-depends.ps1
@@ -5,7 +5,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'a:' 'arch='
 $app = $apps[0]

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -13,7 +13,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 #region Parameter validation
 $opt, $application, $err = getopt $args 'sba:u:' 'skip', 'all-architectures', 'arch=', 'utility='

--- a/libexec/scoop-export.ps1
+++ b/libexec/scoop-export.ps1
@@ -5,7 +5,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 $def_arch = default_architecture
 
 $local = installed_apps $false | ForEach-Object { @{ 'name' = $_; 'global' = $false } }

--- a/libexec/scoop-help.ps1
+++ b/libexec/scoop-help.ps1
@@ -3,42 +3,20 @@
 
 param($cmd)
 
-'core', 'commands', 'help' | ForEach-Object {
+'help', 'Helpers' | ForEach-Object {
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
-
-function print_help($cmd) {
-    $file = Get-Content (command_path $cmd) -raw
-
-    $usage = usage $file
-    $summary = summary $file
-    $help = scoop_help $file
-
-    if ($usage) { "$usage`n" }
-    if ($help) { $help }
-}
-
-function print_summaries {
-    $commands = @{ }
-
-    command_files | ForEach-Object {
-        $command = command_name $_
-        $summary = summary (Get-Content (command_path $command) -raw)
-        if (!($summary)) { $summary = '' }
-        $commands.add("$command ", $summary) # add padding
-    }
-
-    $commands.getenumerator() | Sort-Object Name | Format-Table -HideTableHead -AutoSize -Wrap
-}
+Reset-Alias
 
 $exitCode = 0
 $commands = commands
 
 if (!($cmd)) {
-    Write-UserMessage -Message @(
+    Write-UserMessage -Output -Message @(
         'Usage: scoop <command> [<args>]'
+        ''
+        'Windows command line installer'
         ''
         'General exit codes'
         '   0 - Everything OK'

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -7,7 +7,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'g' 'global'
 if ($err) { Stop-ScoopExecution -Message "scoop hold: $err" -ExitCode 2 }

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -11,25 +11,26 @@ Reset-Alias
 
 $opt, $apps, $err = getopt $args 'g' 'global'
 if ($err) { Stop-ScoopExecution -Message "scoop hold: $err" -ExitCode 2 }
-if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <apps> missing' -Usage (my_usage) }
 
 $global = $opt.g -or $opt.global
 
 if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to interact with globally installed apps' -ExitCode 4 }
 
+$problems = 0
 $exitCode = 0
 foreach ($app in $apps) {
     # Not at all installed
     if (!(installed $app)) {
         Write-UserMessage -Message "'$app' is not installed." -Err
-        $exitCode = 3
+        ++$problems
         continue
     }
 
     # Global required, but not installed globally
     if ($global -and (!(installed $app $global))) {
         Write-UserMessage -Message "'$app' not installed globally" -Err
-        $exitCode = 3
+        ++$problems
         continue
     }
 
@@ -47,5 +48,7 @@ foreach ($app in $apps) {
     save_install_info $install $dir
     Write-UserMessage -Message "$app is now held and can not be updated anymore." -Success
 }
+
+if ($problems -gt 0) { $exitCode = 10 + $problems }
 
 exit $exitCode

--- a/libexec/scoop-hold.ps1
+++ b/libexec/scoop-hold.ps1
@@ -10,18 +10,12 @@
 reset_aliases
 
 $opt, $apps, $err = getopt $args 'g' 'global'
-if ($err) { Write-UserMessage -Message "scoop hold: $err" -Err; exit 2 }
-if (!$apps) { Write-UserMessage -Message '<app> missing' -Err; my_usage; exit 1 }
+if ($err) { Stop-ScoopExecution -Message "scoop hold: $err" -ExitCode 2 }
+if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
 
 $global = $opt.g -or $opt.global
 
-# TODO: Stop-ScoopExecution
-if ($global -and !(is_admin)) { abort 'Admin privileges are required to interact with globally installed apps' 4 }
-
-if (!$apps) {
-    my_usage
-    exit 1
-}
+if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to interact with globally installed apps' -ExitCode 4 }
 
 $exitCode = 0
 foreach ($app in $apps) {

--- a/libexec/scoop-home.ps1
+++ b/libexec/scoop-home.ps1
@@ -7,7 +7,7 @@ param($app)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 $exitCode = 0
 
 if ($app) {

--- a/libexec/scoop-info.ps1
+++ b/libexec/scoop-info.ps1
@@ -7,7 +7,7 @@ param($app)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 if (!$app) { my_usage; exit 1 }
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -1,4 +1,4 @@
-# Usage: scoop install <app> [options]
+# Usage: scoop install <apps> [options]
 # Summary: Install apps
 # Help: e.g. The usual way to install an app (uses your local 'buckets'):
 #   scoop install git
@@ -64,7 +64,7 @@ try {
 } catch {
     Stop-ScoopExecution -Message "ERROR: $_" -ExitCode 2
 }
-if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <apps> missing' -Usage (my_usage) }
 if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to manipulate with globally installed apps' -ExitCode 4 }
 
 if (is_scoop_outdated) { Update-Scoop }

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -21,7 +21,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 function is_installed($app, $global) {
     if ($app.EndsWith('.json')) {

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -49,22 +49,23 @@ function is_installed($app, $global) {
 }
 
 $opt, $apps, $err = getopt $args 'gfiksa:' 'global', 'force', 'independent', 'no-cache', 'skip', 'arch='
-if ($err) { Write-UserMessage -Message "scoop install: $err" -Err; exit 2 }
+if ($err) { Stop-ScoopExecution -Message "scoop install: $err" -ExitCode 2 }
 
+$exitCode = 0
+$problems = 0
 $global = $opt.g -or $opt.global
 $check_hash = !($opt.s -or $opt.skip)
 $independent = $opt.i -or $opt.independent
 $use_cache = !($opt.k -or $opt.'no-cache')
 $architecture = default_architecture
+
 try {
     $architecture = ensure_architecture ($opt.a + $opt.arch)
 } catch {
-    abort "ERROR: $_" 2
+    Stop-ScoopExecution -Message "ERROR: $_" -ExitCode 2
 }
-
-if (!$apps) { Write-UserMessage -Message '<app> missing' -Err; my_usage; exit 1 }
-
-if ($global -and !(is_admin)) { abort 'Admin privileges are required to manipulate with globally installed apps' 4 }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
+if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to manipulate with globally installed apps' -ExitCode 4 }
 
 if (is_scoop_outdated) { Update-Scoop }
 
@@ -75,26 +76,36 @@ if ($apps.length -eq 1) {
     }
 }
 
-# get any specific versions that we need to handle first
+# get any specific versions that need to handled first
 $specific_versions = $apps | Where-Object {
     $null, $null, $version = parse_app $_
     return $null -ne $version
 }
 
 # compare object does not like nulls
-if ($specific_versions.length -gt 0) {
+if ($specific_versions.Length -gt 0) {
     $difference = Compare-Object -ReferenceObject $apps -DifferenceObject $specific_versions -PassThru
 } else {
     $difference = $apps
 }
 
-$specific_versions_paths = $specific_versions | ForEach-Object {
-    $app, $bucket, $version = parse_app $_
+$specific_versions_paths = @()
+foreach ($sp in $specific_versions) {
+    $app, $bucket, $version = parse_app $sp
     if (installed_manifest $app $version) {
-        abort "'$app' ($version) is already installed.`nUse 'scoop update $app$global_flag' to install a new version."
+        Write-UserMessage -Warn -Message @(
+            "'$app' ($version) is already installed.",
+            "Use 'scoop update $app$global_flag' to install a new version."
+        )
+        continue
+    } else {
+        try {
+            $specific_versions_paths += generate_user_manifest $app $bucket $version
+        } catch {
+            Write-UserMessage -Message $_.Exception.Message -Color DarkRed
+            ++$problems
+        }
     }
-
-    generate_user_manifest $app $bucket $version
 }
 $apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-Object -Unique)
 
@@ -115,26 +126,20 @@ $skip | Where-Object { $explicit_apps -contains $_ } | ForEach-Object {
     Write-UserMessage -Message "'$app' ($version) is already installed. Skipping." -Warning
 }
 
-$suggested = @{ };
+$suggested = @{ }
 
-if (Test-Aria2Enabled) {
-    Write-UserMessage -Warning -Message @(
-        "Scoop uses 'aria2c' for multi-connection downloads."
-        "Should it cause issues, run 'scoop config aria2-enabled false' to disable it."
-    )
-}
-
-$exitCode = 0
 foreach ($app in $apps) {
     try {
         install_app $app $architecture $global $suggested $use_cache $check_hash
     } catch {
-        $exitCode = 3
+        ++$problems
         Write-UserMessage -Message $_.Exception.Message -Err
         continue
     }
 }
 
 show_suggestions $suggested
+
+if ($problems -gt 0) { $exitCode = 10 + $problems }
 
 exit $exitCode

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -76,13 +76,13 @@ if ($apps.length -eq 1) {
     }
 }
 
-# get any specific versions that need to handled first
+# Get any specific versions that need to be handled first
 $specific_versions = $apps | Where-Object {
     $null, $null, $version = parse_app $_
     return $null -ne $version
 }
 
-# compare object does not like nulls
+# Compare object does not like nulls
 if ($specific_versions.Length -gt 0) {
     $difference = Compare-Object -ReferenceObject $apps -DifferenceObject $specific_versions -PassThru
 } else {

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -13,7 +13,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $query, $err = getopt $args 'iur' 'installed', 'updated', 'reverse'
 # TODO: Stop-ScoopExecution

--- a/libexec/scoop-list.ps1
+++ b/libexec/scoop-list.ps1
@@ -16,14 +16,12 @@
 Reset-Alias
 
 $opt, $query, $err = getopt $args 'iur' 'installed', 'updated', 'reverse'
-# TODO: Stop-ScoopExecution
-if ($err) { Write-UserMessage -Message "scoop install: $err" -Err; exit 2 }
+if ($err) { Stop-ScoopExecution -Message "scoop install: $err" -ExitCode 2 }
 
 $orderInstalled = $opt.i -or $opt.installed
 $orderUpdated = $opt.u -or $opt.updated
 $reverse = $opt.r -or $opt.reverse
-# TODO: Stop-ScoopExecution
-if ($orderUpdated -and $orderInstalled) { Write-UserMessage -Message '--installed and --updated parameters cannot be used simultaneously' -Err; exit 2 }
+if ($orderUpdated -and $orderInstalled) { Stop-ScoopExecution -Message '--installed and --updated options cannot be used simultaneously' -ExitCode 2 }
 $def_arch = default_architecture
 
 $locA = appsdir $false

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -10,8 +10,9 @@ param($app)
 Reset-Alias
 $exitCode = 0
 
-if (!$app) { my_usage; exit 1 }
+if (!$app) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
 
+# TODO: NO_JUNCTION
 $app_path = versiondir $app 'current' $false
 if (!(Test-Path $app_path)) { $app_path = versiondir $app 'current' $true }
 

--- a/libexec/scoop-prefix.ps1
+++ b/libexec/scoop-prefix.ps1
@@ -7,7 +7,7 @@ param($app)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 $exitCode = 0
 
 if (!$app) { my_usage; exit 1 }

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -11,8 +11,8 @@
 Reset-Alias
 $opt, $apps, $err = getopt $args
 
-if ($err) { Write-UserMessage -Message "scoop reset: $err" -Err; exit 2 }
-if (!$apps) { Write-UserMessage -Message '<app> missing' -Err; my_usage; exit 1 }
+if ($err) { Stop-ScoopExecution -Message "scoop reset: $err" -ExitCode 2 }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
 
 if ($apps -eq '*') {
     $local = installed_apps $false | ForEach-Object { , @($_, $false) }

--- a/libexec/scoop-reset.ps1
+++ b/libexec/scoop-reset.ps1
@@ -8,7 +8,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 $opt, $apps, $err = getopt $args
 
 if ($err) { Write-UserMessage -Message "scoop reset: $err" -Err; exit 2 }

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -12,7 +12,7 @@ param($query)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $exitCode = 0
 

--- a/libexec/scoop-search.ps1
+++ b/libexec/scoop-search.ps1
@@ -120,8 +120,7 @@ Get-LocalBucket | ForEach-Object {
 
 if (!$local_results -and !(github_ratelimit_reached)) {
     $remote_results = search_remotes $query
-    # FIXME
-    if (!$remote_results) { Write-UserMessage -Message 'No matches found.' -Warning; exit 3 }
+    if (!$remote_results) { Stop-ScoopExecution -Message 'No matches found' }
     $remote_results
 }
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -37,9 +37,9 @@ $exitCode = 0
 
 foreach ($global in ($true, $false)) { # local and global apps
     $dir = appsdir $global
-    if (!(Test-Path $dir)) { return }
+    if (!(Test-Path $dir)) { continue }
 
-    foreach ($application in (Get-ChildItem $dir | Where-Object Name -ne 'scoop')){
+    foreach ($application in (Get-ChildItem $dir | Where-Object -Property Name -NE -Value 'scoop')){
         $app = $application.name
         $status = app_status $app $global
         if ($status.failed) {
@@ -65,7 +65,7 @@ if ($outdated) {
     Write-UserMessage -Message 'Updates are available for:' -Color DarkCyan
     $outdated.keys | ForEach-Object {
         $versions = $outdated.$_
-        "    $_`: $($versions[0]) -> $($versions[1])"
+        "    ${_}: $($versions[0]) -> $($versions[1])"
     }
 }
 
@@ -73,7 +73,7 @@ if ($onhold) {
     Write-UserMessage -Message 'These apps are outdated and on hold:' -Color DarkCyan
     $onhold.keys | ForEach-Object {
         $versions = $onhold.$_
-        "    $_`: $($versions[0]) -> $($versions[1])"
+        "    ${_}: $($versions[0]) -> $($versions[1])"
     }
 }
 
@@ -98,7 +98,7 @@ if ($missing_deps) {
     Write-UserMessage 'Missing runtime dependencies:' -Color DarkCyan
     $missing_deps | ForEach-Object {
         $app, $deps = $_
-        "    '$app' requires '$([string]::join("', '", $deps))'"
+        "    '$app' requires '$([String]::Join(', ', $deps))'"
     }
 }
 

--- a/libexec/scoop-status.ps1
+++ b/libexec/scoop-status.ps1
@@ -5,7 +5,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 # check if scoop needs updating
 $currentdir = versiondir 'scoop' 'current'

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -7,7 +7,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'g' 'global'
 if ($err) { Stop-ScoopExecution -Message "scoop unhold: $err" -ExitCode 2 }

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -11,7 +11,7 @@ Reset-Alias
 
 $opt, $apps, $err = getopt $args 'g' 'global'
 if ($err) { Stop-ScoopExecution -Message "scoop unhold: $err" -ExitCode 2 }
-if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
 
 $global = $opt.g -or $opt.global
 

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -1,4 +1,4 @@
-# Usage: scoop unhold <app> [options]
+# Usage: scoop unhold <apps> [options]
 # Summary: Unhold an app to enable updates
 # Options:
 #   -g, --global              Unhold globally installed app
@@ -11,25 +11,26 @@ Reset-Alias
 
 $opt, $apps, $err = getopt $args 'g' 'global'
 if ($err) { Stop-ScoopExecution -Message "scoop unhold: $err" -ExitCode 2 }
-if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <apps> missing' -Usage (my_usage) }
 
 $global = $opt.g -or $opt.global
 
 if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to interact with globally installed apps' -ExitCode 4 }
 
+$problems = 0
 $exitCode = 0
 foreach ($app in $apps) {
     # Not at all installed
     if (!(installed $app)) {
         Write-UserMessage -Message "'$app' is not installed." -Err
-        $exitCode = 3
+        ++$problems
         continue
     }
 
     # Global required, but not installed globally
     if ($global -and (!(installed $app $global))) {
         Write-UserMessage -Message "'$app' not installed globally" -Err
-        $exitCode = 3
+        ++$problems
         continue
     }
 
@@ -47,5 +48,7 @@ foreach ($app in $apps) {
     save_install_info $install $dir
     Write-UserMessage -Message "$app is no longer held and can be updated again." -Success
 }
+
+if ($problems -gt 0) { $exitCode = 10 + $problems }
 
 exit $exitCode

--- a/libexec/scoop-unhold.ps1
+++ b/libexec/scoop-unhold.ps1
@@ -10,18 +10,12 @@
 reset_aliases
 
 $opt, $apps, $err = getopt $args 'g' 'global'
-if ($err) { Write-UserMessage -Message "scoop unhold: $err" -Err; exit 2 }
-if (!$apps) { Write-UserMessage -Message '<app> missing' -Err; my_usage; exit 1 }
+if ($err) { Stop-ScoopExecution -Message "scoop unhold: $err" -ExitCode 2 }
+if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
 
 $global = $opt.g -or $opt.global
 
-# TODO: Stop-ScoopExecution
-if ($global -and !(is_admin)) { abort 'Admin privileges are required to interact with globally installed apps' 4 }
-
-if (!$apps) {
-    my_usage
-    exit 1
-}
+if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to interact with globally installed apps' -ExitCode 4 }
 
 $exitCode = 0
 foreach ($app in $apps) {

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -10,7 +10,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 # options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -19,7 +19,7 @@ if ($err) { Stop-ScoopExecution -Message "scoop uninstall: $err" -ExitCode 2 }
 $global = $opt.g -or $opt.global
 $purge = $opt.p -or $opt.purge
 
-if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Parameter <app> missing' -Usage (my_usage) }
 
 if ($global -and !(is_admin)) {
     Stop-ScoopExecution -Message 'Administrator privileges are required to uninstall global apps.' -ExitCode 4

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -12,26 +12,17 @@
 
 Reset-Alias
 
-# options
 $opt, $apps, $err = getopt $args 'gp' 'global', 'purge'
 
-if ($err) {
-    Write-UserMessage -Message "scoop uninstall: $err" -Err
-    exit 2
-}
+if ($err) { Stop-ScoopExecution -Message "scoop uninstall: $err" -ExitCode 2 }
 
 $global = $opt.g -or $opt.global
 $purge = $opt.p -or $opt.purge
 
-if (!$apps) {
-    Write-UserMessage -Message '<app> missing' -Err
-    my_usage
-    exit 1
-}
+if (!$apps) { Stop-ScoopExecution -Message '<app> missing' -Usage (my_usage) }
 
 if ($global -and !(is_admin)) {
-    Write-UserMessage -Message 'Administrator privileges are required to uninstall global apps.' -Err
-    exit 4
+    Stop-ScoopExecution -Message 'Administrator privileges are required to uninstall global apps.' -ExitCode 4
 }
 
 if ($apps -eq 'scoop') {
@@ -41,8 +32,7 @@ if ($apps -eq 'scoop') {
 
 $apps = Confirm-InstallationStatus $apps -Global:$global
 if (!$apps) {
-    Write-UserMessage -Message 'No application to uninstall' -Warning
-    exit 3
+    Stop-ScoopExecution -Message 'No application to uninstall' -ExitCode 3 -SkipSeverity
 }
 
 $exitCode = 0

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -32,8 +32,8 @@ $independent = $opt.i -or $opt.independent
 
 $exitCode = 0
 if (!$apps) {
-    if ($global) { Stop-ScoopExecution -Message 'scoop update: --global is invalid when <app> is not specified.' -ExitCode 2 }
-    if (!$useCache) { Stop-ScoopExecution -Message 'scoop update: --no-cache is invalid when <app> is not specified.' -ExitCode 2 }
+    if ($global) { Stop-ScoopExecution -Message 'scoop update: --global option is invalid when <app> is not specified.' -ExitCode 2 }
+    if (!$useCache) { Stop-ScoopExecution -Message 'scoop update: --no-cache option is invalid when <app> is not specified.' -ExitCode 2 }
 
     Update-Scoop
 } else {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -20,8 +20,7 @@
 Reset-Alias
 
 $opt, $apps, $err = getopt $args 'gfiksq' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet'
-# TODO: Stop-ScoopExecution
-if ($err) { Write-UserMessage -Message "scoop update: $err" -Err; exit 2 }
+if ($err) { Stop-ScoopExecution -Message "scoop update: $err" -ExitCode 2 }
 
 # Flags/Parameters
 $global = $opt.g -or $opt.global
@@ -33,15 +32,12 @@ $independent = $opt.i -or $opt.independent
 
 $exitCode = 0
 if (!$apps) {
-    # TODO: Stop-ScoopExecution
-    if ($global) { Write-UserMessage -Message 'scoop update: --global is invalid when <app> is not specified.' -Err; exit 2 }
-    if (!$useCache) { Write-UserMessage -Message 'scoop update: --no-cache is invalid when <app> is not specified.' -Err; exit 2 }
+    if ($global) { Stop-ScoopExecution -Message 'scoop update: --global is invalid when <app> is not specified.' -ExitCode 2 }
+    if (!$useCache) { Stop-ScoopExecution -Message 'scoop update: --no-cache is invalid when <app> is not specified.' -ExitCode 2 }
 
     Update-Scoop
 } else {
-    # TODO: Stop-ScoopExecution
-    if ($global -and !(is_admin)) { Write-UserMessage -Message 'You need admin rights to update global apps.' -Err; exit 4 }
-
+    if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to manipulate with globally installed apps' -ExitCode 4 }
     if (is_scoop_outdated) { Update-Scoop }
     $outdatedApplications = @()
     $applicationsParam = $apps

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -17,7 +17,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'gfiksq' 'global', 'force', 'independent', 'no-cache', 'skip', 'quiet'
 # TODO: Stop-ScoopExecution

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -38,7 +38,7 @@
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 $opt, $apps, $err = getopt $args 'a:sn' 'arch=', 'scan', 'no-depends'
 if ($err) { Write-UserMessage "scoop virustotal: $err"; exit 1 }

--- a/libexec/scoop-virustotal.ps1
+++ b/libexec/scoop-virustotal.ps1
@@ -42,7 +42,7 @@ Reset-Alias
 
 $opt, $apps, $err = getopt $args 'a:sn' 'arch=', 'scan', 'no-depends'
 if ($err) { Stop-ScoopExecution -Message "scoop virustotal: $err" -ExitCode 2 }
-if (!$apps) { Stop-ScoopExecution -Message 'Application missing' -Usage (my_usage) }
+if (!$apps) { Stop-ScoopExecution -Message 'Application parameter missing' -Usage (my_usage) }
 
 $architecture = ensure_architecture ($opt.a + $opt.arch)
 $DoScan = $opt.scan -or $opt.s
@@ -72,7 +72,7 @@ foreach ($app in $apps) {
             } else {
                 Write-UserMessage -Message "${app}: Can not find hash for $url" -Warning
             }
-        } catch [Exception] {
+        } catch {
             $exitCode = $exitCode -bor $VT_ERR.Exception
 
             if ($_.Exception.Message -like '*(404)*') {

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -10,7 +10,7 @@ param([String] $Command)
 
 Reset-Alias
 
-if (!$command) { Stop-ScoopExecution -Message '<command> missing' -Usage (my_usage) }
+if (!$command) { Stop-ScoopExecution -Message 'Parameter <command> missing' -Usage (my_usage) }
 
 try {
     $gcm = Get-Command $Command -ErrorAction Stop
@@ -40,7 +40,7 @@ if ($gcm.Path -and $gcm.Path.EndsWith('.ps1') -and (($gcm.Path -like "$userShims
     switch ($gcm.CommandType) {
         'Application' { $FINAL_PATH = $gcm.Source }
         'Alias' {
-            $FINAL_PATH = Invoke-ScoopCommand 'which'  @{ 'Command' = $gcm.ResolvedCommandName }
+            $FINAL_PATH = Invoke-ScoopCommand 'which' @{ 'Command' = $gcm.ResolvedCommandName }
             $exitCode = 3
         }
         default {

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -41,7 +41,7 @@ if ($gcm.Path -and $gcm.Path.EndsWith('.ps1') -and (($gcm.Path -like "$userShims
         'Application' { $FINAL_PATH = $gcm.Source }
         'Alias' {
             $FINAL_PATH = Invoke-ScoopCommand 'which' @{ 'Command' = $gcm.ResolvedCommandName }
-            $exitCode = 3
+            $exitCode = $LASTEXITCODE
         }
         default {
             Write-UserMessage -Message 'Not a scoop shim'

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -10,13 +10,12 @@ param([String] $Command)
 
 Reset-Alias
 
-if (!$command) { Write-UserMessage '<command> missing' -Err; my_usage; exit 1 }
+if (!$command) { Stop-ScoopExecution -Message '<command> missing' -Usage (my_usage) }
 
 try {
     $gcm = Get-Command $Command -ErrorAction Stop
 } catch {
-    # TODO: Stop-ScoopExecution
-    abort "Command '$command' not found" 3
+    Stop-ScoopExecution -Message "Command '$command' not found"
 }
 
 $userShims = shimdir $false | Resolve-Path
@@ -40,7 +39,10 @@ if ($gcm.Path -and $gcm.Path.EndsWith('.ps1') -and (($gcm.Path -like "$userShims
 } else {
     switch ($gcm.CommandType) {
         'Application' { $FINAL_PATH = $gcm.Source }
-        'Alias' { $FINAL_PATH = exec 'which'  @{ 'Command' = $gcm.ResolvedCommandName } }
+        'Alias' {
+            $FINAL_PATH = Invoke-ScoopCommand 'which'  @{ 'Command' = $gcm.ResolvedCommandName }
+            $exitCode = 3
+        }
         default {
             Write-UserMessage -Message 'Not a scoop shim'
             $FINAL_PATH = $gcm.Path
@@ -49,6 +51,6 @@ if ($gcm.Path -and $gcm.Path.EndsWith('.ps1') -and (($gcm.Path -like "$userShims
     }
 }
 
-if ($FINAL_PATH) { Write-UserMessage $FINAL_PATH }
+if ($FINAL_PATH) { Write-UserMessage -Message $FINAL_PATH -Output }
 
 exit $exitCode

--- a/libexec/scoop-which.ps1
+++ b/libexec/scoop-which.ps1
@@ -8,7 +8,7 @@ param([String] $Command)
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
-reset_aliases
+Reset-Alias
 
 if (!$command) { Write-UserMessage '<command> missing' -Err; my_usage; exit 1 }
 

--- a/test/Scoop-Core.Tests.ps1
+++ b/test/Scoop-Core.Tests.ps1
@@ -257,7 +257,7 @@ Describe "ensure_robocopy_in_path" -Tag 'Scoop' {
     Mock versiondir { $repo_dir }
 
     BeforeAll {
-        reset_aliases
+        Reset-Alias
     }
 
     Context "robocopy is not in path" {


### PR DESCRIPTION
Present `Stop-ScoopExecution` function

Move reset_aliases into Helpers from core

- bin\scoop
- libexec
    - help
    - hold
    - unhold

#46, #21, #16 