### PR TITLE
refactor: Straightforward abort deprecation

### DIFF
--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -52,7 +52,7 @@ param(
     [Switch] $SkipCheckver
 )
 
-'manifest', 'json' | ForEach-Object {
+'Helpers', 'manifest', 'json' | ForEach-Object {
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
@@ -77,17 +77,14 @@ Optional options:
 }
 
 if (!(Get-Command -Name 'hub' -CommandType Application -ErrorAction SilentlyContinue)) {
-    # TODO: Stop-ScoopExecution
-    Write-UserMessage -Message 'hub is required! Please refer to ''https://hub.github.com/'' to find out how to get hub for your platform.' -Warning
-    exit 1
+    Stop-ScoopExecution -Message 'hub is required! Please refer to ''https://hub.github.com/'' to find out how to get hub for your platform.'
 }
 
 function execute($cmd) {
     Write-Host $cmd -ForegroundColor Green
     $output = Invoke-Expression $cmd
 
-    # TODO: Stop-ScoopExecution
-    if ($LASTEXITCODE -gt 0) { abort "^^^ Error! See above ^^^ (last command: $cmd)" }
+    if ($LASTEXITCODE -gt 0) { Stop-ScoopExecution -Message "^^^ Error! See above ^^^ (last command: $cmd)" }
 
     return $output
 }
@@ -137,7 +134,7 @@ a new version of [$app]($homepage) is available.
     hub pull-request -m "$msg" -b '$upstream' -h '$branch'
     if ($LASTEXITCODE -gt 0) {
         execute 'hub reset'
-        abort "Pull Request failed! (hub pull-request -m '${app}: Update to version $version' -b '$upstream' -h '$branch')"
+        Stop-ScoopExecution -Message "Pull Request failed! (hub pull-request -m '${app}: Update to version $version' -b '$upstream' -h '$branch')"
     }
 }
 

--- a/bin/uninstall.ps1
+++ b/bin/uninstall.ps1
@@ -11,14 +11,12 @@ param(
     [bool] $purge
 )
 
-'core', 'install', 'shortcuts', 'Versions', 'manifest', 'uninstall' | ForEach-Object {
+'core', 'Helpers', 'install', 'shortcuts', 'Versions', 'manifest', 'uninstall' | ForEach-Object {
     . (Join-Path $PSScriptRoot "..\lib\$_.ps1")
 }
 
 if ($global -and !(is_admin)) {
-    # TODO: Stop-ScoopExecution
-    Write-UserMessage -Message 'You need admin rights to uninstall globally.' -Err
-    exit 1
+    Stop-ScoopExecution -Message 'Admin privileges are required for globall uninstallation.' -ExitCode 4
 }
 
 $message = 'This will uninstall Scoop and all the programs that have been installed with Scoop!'
@@ -36,8 +34,7 @@ function rm_dir($dir) {
     try {
         Remove-Item $dir -ErrorAction Stop -Recurse -Force
     } catch {
-        # TODO: Stop-ScoopExecution
-        abort "Couldn't remove $(friendly_path $dir): $_"
+        Stop-ScoopExecution -Message "Couldn't remove $(friendly_path $dir): $_"
     }
 }
 
@@ -60,7 +57,7 @@ installed_apps $false | ForEach-Object { # local apps
     if ($result -eq $false) { $errors += 1 }
 }
 
-if ($errors -gt 0) { abort 'Not all apps could be deleted. Try again or restart.' }
+if ($errors -gt 0) { Stop-ScoopExecution -Message 'Not all apps could be deleted. Try again or restart.' }
 
 if ($purge) {
     rm_dir $SCOOP_ROOT_DIRECTORY

--- a/lib/Update.ps1
+++ b/lib/Update.ps1
@@ -34,8 +34,7 @@ function Update-ScoopCoreClone {
     Invoke-GitCmd -Command 'clone' -Argument '--quiet', '--single-branch', '--branch', """$Branch""", $Repo, """$newDir""" -Proxy
 
     # Check if scoop was successful downloaded
-    # TODO: Stop-ScoopExecution
-    if (!(Test-Path $newDir -PathType Container)) { abort 'Scoop update failed.' }
+    if (!(Test-Path $newDir -PathType Container)) { Stop-ScoopExecution -Message 'Scoop update failed.' }
 
     # Replace non-git scoop with the git version
     Remove-Item $TargetDirectory -ErrorAction Stop -Force -Recurse
@@ -92,8 +91,7 @@ function Update-ScoopCorePull {
     $res = $LASTEXITCODE
     if ($SHOW_UPDATE_LOG) { Invoke-GitCmd @target -Command 'UpdateLog' -Argument """$previousCommit..HEAD""" }
 
-    # TODO: Stop-ScoopExecution
-    if ($res -ne 0) { abort 'Update failed.' }
+    if ($res -ne 0) { Stop-ScoopExecution -Message 'Update failed.' }
 }
 
 function Update-ScoopLocalBucket {
@@ -308,6 +306,6 @@ function Update-App {
 
     $toUpdate = if ($install.url) { $install.url } else { "$bucket/$App" }
 
-    # TODO: Try catch
+    # Error catching should be handled on upper scope
     install_app $toUpdate $architecture $Global $Suggested (!$SkipCache) (!$SkipHashCheck)
 }

--- a/lib/buckets.ps1
+++ b/lib/buckets.ps1
@@ -135,7 +135,7 @@ function Remove-Bucket {
     }
 }
 
-# TODO: Migrate to helpers
+# TODO: Drop/Deprecate
 function new_issue_msg($app, $bucket, $title, $body) {
     $app, $manifest, $bucket, $url = Find-Manifest $app $bucket
     $url = known_bucket_repo $bucket

--- a/lib/depends.ps1
+++ b/lib/depends.ps1
@@ -49,7 +49,7 @@ function dep_resolve($app, $arch, $resolved, $unresolved) {
             dep_resolve $dep $arch $resolved $unresolved
         }
     }
-    $resolved.add($app) | Out-Null
+    $resolved.Add($app) | Out-Null
     $unresolved = $unresolved -ne $app # Remove from unresolved
 }
 

--- a/libexec/scoop-install.ps1
+++ b/libexec/scoop-install.ps1
@@ -36,6 +36,7 @@ function is_installed($app, $global) {
                 "It looks like a previous installation of $app failed."
                 "Run 'scoop uninstall $app$(gf $global)' before retrying the install."
             )
+            return $true
         }
         Write-UserMessage -Warning -Message @(
             "'$app' ($version) is already installed.",
@@ -68,13 +69,6 @@ if (!$apps) { Stop-ScoopExecution -Message 'Parameter <apps> missing' -Usage (my
 if ($global -and !(is_admin)) { Stop-ScoopExecution -Message 'Admin privileges are required to manipulate with globally installed apps' -ExitCode 4 }
 
 if (is_scoop_outdated) { Update-Scoop }
-
-if ($apps.length -eq 1) {
-    $app, $null, $version = parse_app $apps
-    if ($null -eq $version -and (is_installed $app $global)) {
-        return
-    }
-}
 
 # Get any specific versions that need to be handled first
 $specific_versions = $apps | Where-Object {
@@ -109,7 +103,7 @@ foreach ($sp in $specific_versions) {
 }
 $apps = @(($specific_versions_paths + $difference) | Where-Object { $_ } | Sort-Object -Unique)
 
-# remember which were explictly requested so that we can
+# Remember which were explictly requested so that we can
 # differentiate after dependencies are added
 $explicit_apps = $apps
 

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -43,7 +43,14 @@ $problems = 0
 :app_loop foreach ($_ in $apps) {
     ($app, $global) = $_
 
-    $result = Uninstall-ScoopApplication -App $app -Global:$global -Purge:$purge -Older
+    try {
+        $result = Uninstall-ScoopApplication -App $app -Global:$global -Purge:$purge -Older
+    } catch {
+        ++$problems
+        Write-UserMessage -Message $_.Exception.Message -Err
+        continue
+    }
+
     if ($result -eq $false) {
         ++$problems
         continue

--- a/libexec/scoop-uninstall.ps1
+++ b/libexec/scoop-uninstall.ps1
@@ -43,6 +43,7 @@ $problems = 0
 :app_loop foreach ($_ in $apps) {
     ($app, $global) = $_
 
+    $result = $false
     try {
         $result = Uninstall-ScoopApplication -App $app -Global:$global -Purge:$purge -Older
     } catch {

--- a/libexec/scoop-update.ps1
+++ b/libexec/scoop-update.ps1
@@ -82,6 +82,7 @@ if (!$apps) {
         } catch {
             ++$problems
             Write-UserMessage -Message $_.Exception.Message -Err
+            continue
         }
     }
 }


### PR DESCRIPTION
#46, #53

I did not expect that full deprecation will be that easy in general, so the original PR grows a bit and got really messy.
This is fraction of the previous PR with the easiest changes.

- Helper function
- Strict and safe `abort` replacement without additional side checks