### PR TITLE
feat(scoop-download): Adopt Resolve-ManifestInformation

### DIFF
--- a/lib/install.ps1
+++ b/lib/install.ps1
@@ -139,7 +139,7 @@ function dl_with_cache($app, $version, $url, $to, $cookies = $null, $use_cache =
     $cached = cache_path $app $version $url
 
     if (!(Test-Path $cached) -or !$use_cache) {
-        ensure $cachedir | Out-Null
+        Confirm-DirectoryExistence $SCOOP_CACHE_DIRECTORY | Out-Null
         do_dl $url "$cached.download" $cookies
         Move-Item "$cached.download" $cached -Force
     } else { Write-UserMessage -Message "Loading $(url_remote_filename $url) from cache" }
@@ -294,7 +294,7 @@ function dl_with_cache_aria2($app, $version, $manifest, $architecture, $dir, $co
             if (($url -notlike '*sourceforge.net*') -and ($url -notlike '*portableapps.com*')) {
                 $urlstxt_content += "    referer=$(strip_filename $url)`n"
             }
-            $urlstxt_content += "    dir=$cachedir`n"
+            $urlstxt_content += "    dir=$SCOOP_CACHE_DIRECTORY`n"
             $urlstxt_content += "    out=$($data.$url.cachename)`n"
         } else {
             Write-Host 'Loading ' -NoNewline

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -328,7 +328,12 @@ function Get-ManifestFromLookup {
         }
 
         $name = $requestedName
-        $manifest = ConvertFrom-Manifest -LiteralPath $manifestPath
+        $manifest = $null
+        try {
+            $manifest = ConvertFrom-Manifest -LiteralPath $manifestPath
+        } catch {
+            throw [ScoopException] "'$manifestPath': Invalid manifest ($($_.Exception.Message))"
+        }
 
         return @{
             'Name'     = $name

--- a/lib/manifest.ps1
+++ b/lib/manifest.ps1
@@ -306,7 +306,7 @@ function Get-ManifestFromLookup {
         # Select versioned manifest or generate it
         if ($requestedVersion) {
             try {
-                $path = manifest_path -app $requestedName -bucket $requestedBucket -version $requestedVersion
+                $path = manifest_path -app $requestedName -bucket $manifestBucket -version $requestedVersion
                 if ($null -eq $path) { throw 'trigger' }
                 $manifestPath = $path
             } catch {

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -25,68 +25,50 @@ $utility = $opt.u, $opt.utility, 'native' | Where-Object { -not [String]::IsNull
 if (!$application) { Stop-ScoopExecution -Message 'Parameter <APP> missing' }
 if (($utility -eq 'aria2') -and (!(Test-HelperInstalled -Helper Aria2))) { Stop-ScoopExecution -Message 'Aria2 is not installed' }
 
-$architecture = Resolve-ArchitectureParameter -Architecture $opt.a, $opt.arch
+$Architecture = Resolve-ArchitectureParameter -Architecture $opt.a, $opt.arch
 
 # Add all supported architectures
-if ($opt.b -or $opt.'all-architectures') { $architecture = '32bit', '64bit' }
+if ($opt.b -or $opt.'all-architectures') { $Architecture = '32bit', '64bit' }
 #endregion Parameter validation
 
 $exitCode = 0
 $problems = 0
+
 foreach ($app in $application) {
-    # Prevent leaking variables from previous iteration
-    $cleanAppName = $bucket = $version = $appName = $manifest = $foundBucket = $url = $null
-
-    # TODO: Adopt Resolve-ManifestInformation
-    $cleanAppName, $bucket, $version = parse_app $app
-    $appName, $manifest, $foundBucket, $url = Find-Manifest $cleanAppName $bucket
-    if ($null -eq $bucket) { $bucket = $foundBucket }
-
-    # Handle potential use case, which should not appear, but just in case
-    # If parsed name/bucket is not same as the provided one
-    if ((-not $url) -and (($cleanAppName -ne $appName) -or ($bucket -ne $foundBucket))) {
-        debug $bucket
-        debug $cleanAppName
-        debug $foundBucket
-        debug $appName
-
-        Write-UserMessage -Message 'Found application name or bucket is not same as requested' -Err
+    $resolved = $null
+    try {
+        $resolved = Resolve-ManifestInformation -ApplicationQuery $app
+    } catch {
         ++$problems
 
-        continue
+        $title, $body = $_.Exception.Message -split '\|-'
+        if (!$body) { $body = $title }
+        Write-UserMessage -Message $body -Err
+        debug $_.InvocationInfo
+        if ($title -ne 'Ignore' -and ($title -ne $body)) { New-IssuePrompt -Application $appName -Bucket $bucket -Title $title -Body $body }
     }
 
-    # Generate manifest if there is different version in manifest
-    if (($null -ne $version) -and ($manifest.version -ne $version)) {
-        try {
-            $generated = generate_user_manifest $appName $bucket $version
-            if ($null -eq $generated) {
-                throw [ScoopException] ''
-            }
-        } catch {
-            Write-UserMessage -Message 'Archived manifest does not exist and version specific manifest cannot be generated with provided version' -Err
-            ++$problems
+    debug $resolved
 
-            continue
-        }
-        $manifest = parse_json $generated
-    }
-
-    if (-not $version) { $version = $manifest.version }
+    # TODO: Remove not neeeded variables. Keep them for now just for less changes
+    $appName = $resolved.Name
+    $manifest = $resolved.ManifestObject
+    $bucket = $resolved.Bucket
+    $version = $manifest.version
     if ($version -eq 'nightly') {
         $version = nightly_version (Get-Date)
         $checkHash = $false
     }
 
-    Write-UserMessage "Starting download for $app" -Color 'Green'
+    Write-UserMessage "Starting download for '$app'" -Color 'Green'
 
     $registered = $false
     # TODO: Rework with proper wrappers after #3149
     switch ($utility) {
         'aria2' {
-            foreach ($arch in $architecture) {
+            foreach ($arch in $Architecture) {
                 try {
-                    dl_with_cache_aria2 $appName $version $manifest $arch $cachedir $manifest.cookie $true $checkHash
+                    dl_with_cache_aria2 $appName $version $manifest $arch $SCOOP_CACHE_DIRECTORY $manifest.cookie $true $checkHash
                 } catch {
                     # Do not count specific architectures or URLs
                     if (!$registered) {
@@ -106,7 +88,7 @@ foreach ($app in $application) {
         }
 
         'native' {
-            foreach ($arch in $architecture) {
+            foreach ($arch in $Architecture) {
                 foreach ($url in (url $manifest $arch)) {
                     try {
                         dl_with_cache $appName $version $url $null $manifest.cookie $true

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -62,7 +62,7 @@ foreach ($app in $application) {
         $checkHash = $false
     }
 
-    Write-UserMessage "Starting download for '$app'" -Color 'Green'
+    Write-UserMessage "Starting download for '$app'" -Color 'Green' # TODO: Add better text with parsed appname, version, url/bucket
 
     $registered = $false
     # TODO: Rework with proper wrappers after #3149

--- a/libexec/scoop-download.ps1
+++ b/libexec/scoop-download.ps1
@@ -46,6 +46,8 @@ foreach ($app in $application) {
         Write-UserMessage -Message $body -Err
         debug $_.InvocationInfo
         if ($title -ne 'Ignore' -and ($title -ne $body)) { New-IssuePrompt -Application $appName -Bucket $bucket -Title $title -Body $body }
+
+        continue
     }
 
     debug $resolved

--- a/test/Scoop-Config.Tests.ps1
+++ b/test/Scoop-Config.Tests.ps1
@@ -52,11 +52,11 @@ Describe 'config' -Tag 'Scoop' {
 
     <#
     It "set_config should create a new PSObject and ensure existing directory" {
-        $scoopConfig = $null
-        $configFile = "$PSScriptRoot\.scoop"
+        $SCOOP_CONFIGURATION = $null
+        $SCOOP_CONFIGURATION_FILE = "$PSScriptRoot\.scoop"
 
-        Mock ensure { $PSScriptRoot } -Verifiable -ParameterFilter { $dir -eq (Split-Path -Path $configFile) }
-        Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $configFile }
+        Mock ensure { $PSScriptRoot } -Verifiable -ParameterFilter { $dir -eq (Split-Path -Path $SCOOP_CONFIGURATION_FILE) }
+        Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $SCOOP_CONFIGURATION_FILE }
         Mock ConvertTo-Json { '' } -Verifiable -ParameterFilter { $InputObject -is [System.Management.Automation.PSObject] }
 
         set_config 'does_not_exist' 'default'
@@ -65,17 +65,17 @@ Describe 'config' -Tag 'Scoop' {
     }
 
     It "set_config should remove a value if set to `$null" {
-        $scoopConfig = New-Object PSObject
-        $scoopConfig | Add-Member -MemberType NoteProperty -Name 'should_be_removed' -Value 'a_value'
-        $scoopConfig | Add-Member -MemberType NoteProperty -Name 'should_stay' -Value 'another_value'
-        $configFile = "$PSScriptRoot\.scoop"
+        $SCOOP_CONFIGURATION = New-Object PSObject
+        $SCOOP_CONFIGURATION | Add-Member -MemberType NoteProperty -Name 'should_be_removed' -Value 'a_value'
+        $SCOOP_CONFIGURATION | Add-Member -MemberType NoteProperty -Name 'should_stay' -Value 'another_value'
+        $SCOOP_CONFIGURATION_FILE = "$PSScriptRoot\.scoop"
 
-        Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $configFile }
+        Mock Set-Content { } -Verifiable -ParameterFilter { $Path -eq $SCOOP_CONFIGURATION_FILE }
         Mock ConvertTo-Json { '' } -Verifiable -ParameterFilter { $InputObject -is [System.Management.Automation.PSObject] }
 
-        $scoopConfig = set_config 'should_be_removed' $null
-        $scoopConfig.should_be_removed | Should -BeNullOrEmpty
-        $scoopConfig.should_stay | Should -Be 'another_value'
+        $SCOOP_CONFIGURATION = set_config 'should_be_removed' $null
+        $SCOOP_CONFIGURATION.should_be_removed | Should -BeNullOrEmpty
+        $SCOOP_CONFIGURATION.should_stay | Should -Be 'another_value'
 
         Assert-VerifiableMock
     }


### PR DESCRIPTION
#140

- [x] Properly test *nix

Support all types of parameter passed with versioning and automatic regenerations:
- `pwsh`
- `pwsh@7.2.0`
- `Ash258/pwsh`
- `Ash258/pwsh@6.1.3`
- `.\bucket\old\cosi\7.1.0.yaml`
- `.\cosi.yaml`
- `https://raw.githubusercontent.com/Ash258/GithubActionsBucketForTesting/main/bucket/alfa.yaml`
- `https://raw.githubusercontent.com/Ash258/GithubActionsBucketForTesting/main/bucket/old/alfa/0.0.15-12060.yaml`

YAML manifest support

![image](https://user-images.githubusercontent.com/13260377/120383412-22346f00-c325-11eb-81ec-d99bd27ec854.png)
